### PR TITLE
chore: firebase emulator data now persists after exit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ Thumbs.db
 *-debug.log
 .runtimeconfig.json
 firebaseConfig.ts
+.dev-data

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "serve": "npm run watch | firebase emulators:start"
+    "serve": "npm run watch | firebase emulators:start --import=./.dev-data --export-on-exit=./.dev-data" 
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Data created when running the firebase emulators locally now persists after exit and restart. The data is saved locally in an untracked `.dev-data` folder.