### PR TITLE
feat: delete entities; use a specified field as entity's display name

### DIFF
--- a/src/app/components/entity-detail/entity-detail.component.html
+++ b/src/app/components/entity-detail/entity-detail.component.html
@@ -1,21 +1,44 @@
 <div class="entity-container">
-  <div class="title">
-    <h2>{{ entity?.name }}</h2>
-  </div>
-  <div class="fields-container">
-    <div *ngIf="!editing">
-      <div *ngFor="let field of entityWithFields?.fields" class="field">
+  <ng-container *ngIf="deleted">
+    Entity deleted
+    <br>
+    <button [routerLink]="['/entities']">Return</button>
+  </ng-container>
+  <ng-container *ngIf="!deleted">
+    <div class="title">
+      <h2>{{ entityWithFields?.displayField?.value }}</h2>
+    </div>
+    <div class="fields-container">
+      <div *ngIf="!editing">
+        <div *ngFor="let field of entityWithFields?.fields" class="field">
+          <div>{{ field.field }}: {{ field.value }}</div>
+        </div>
+      </div>
+      <div *ngIf="editing">
         <div>
-          {{ field.field }}: {{ field.value }}
+          Entity name (legacy, copy over to relevant field): {{ entity?.name }}
+        </div>
+        <app-dynamic-form
+          [fields]="fields!"
+          (newPayloadEvent)="handlePayload($event)"
+        ></app-dynamic-form>
+      </div>
+      <button (click)="toggleEditing()">
+        {{ editing ? "Cancel" : "Edit Fields" }}
+      </button>
+      <app-tags [entity]="entity"></app-tags>
+      <div class="delete-section">
+        <button *ngIf="!deleting" (click)="toggleDeleting()" class="btn-danger">
+          Delete
+        </button>
+        <div *ngIf="deleting">
+          Are you sure you want to delete
+          {{ entityWithFields?.displayField?.value || "this entity" }}?
+          <br />
+          <button (click)="toggleDeleting()">Cancel</button>
+          <button (click)="deleteEntity()" class="btn-danger">Delete</button>
         </div>
       </div>
     </div>
-    <div *ngIf="editing">
-      <app-dynamic-form [fields]="fields!" (newPayloadEvent)="handlePayload($event)"></app-dynamic-form>
-    </div>
-    <button (click)="toggleEditing()">
-      {{ editing ? "Cancel" : "Edit Fields" }}
-    </button>
-    <app-tags [entity]="entity"></app-tags>
-  </div>
+  </ng-container>
 </div>

--- a/src/app/components/entity-detail/entity-detail.component.scss
+++ b/src/app/components/entity-detail/entity-detail.component.scss
@@ -8,4 +8,7 @@
       margin: 0.5rem 0;
     }
   }
+  .delete-section {
+    margin-top: 16px
+  }
 }

--- a/src/app/components/entity-detail/entity-detail.component.ts
+++ b/src/app/components/entity-detail/entity-detail.component.ts
@@ -13,6 +13,8 @@ import { FieldBase } from 'src/app/shared/dynamic-form/field-base';
 })
 export class EntityDetailComponent extends EntityComponent implements OnInit, OnDestroy {
   fields: FieldBase<any>[] | undefined;
+  deleting: boolean = false;
+  deleted: boolean = false;
   queryParamsSubscription: Subscription | undefined;
 
   constructor(entityService: EntityService, private route: ActivatedRoute, private fieldService: FieldService) {
@@ -21,11 +23,12 @@ export class EntityDetailComponent extends EntityComponent implements OnInit, On
 
   override async ngOnInit() {
     this.queryParamsSubscription = this.route.queryParams.subscribe(async params => {
-      this.entityId = params['id']
+      this.entityId = params["id"]
       await super.ngOnInit()
       this.fields = this.entityWithFields?.fields?.map((field) => {
         return this.fieldService.convertFieldToFormField(field)
       })
+      this.editing = params["editing"]
 
       // Better to use entityService.getFields(id) that returns observable ? Then use like this:
       // this.fields$ = this.fieldService.getFields()
@@ -37,6 +40,15 @@ export class EntityDetailComponent extends EntityComponent implements OnInit, On
     this.queryParamsSubscription?.unsubscribe()
     this.editing = false
     await this.ngOnInit()
+  }
+
+  toggleDeleting() {
+    this.deleting = !this.deleting
+  }
+
+  async deleteEntity() {
+    await this.entityService.deleteEntity(this.entity!.id)
+    this.deleted = true
   }
 
   ngOnDestroy() {

--- a/src/app/components/entity/entity.component.html
+++ b/src/app/components/entity/entity.component.html
@@ -1,20 +1,20 @@
 <div class="entity-container">
   <div class="banner"  (click)="toggleExpanded()">
     <div class="title">
-      <h3>{{ entity?.name }}</h3>
+      <h3>{{ entityWithFields?.displayField?.value }}</h3>
     </div>
     <div class="icon">
       {{ expanded ? "–" : "+" }}
     </div>
   </div>
   <div *ngIf="expanded">
+    <button [routerLink]="['/entity']" [queryParams]="{id: entity?.id}" queryParamsHandling="merge">
+      Edit
+    </button>
     <div class="fields-container">
       <div *ngFor="let field of entityWithFields?.fields" class="field">
         {{ field.field }}: {{ field.value }}
       </div>
-      <a [routerLink]="['/entity']" [queryParams]="{id: entity?.id}" queryParamsHandling="merge">
-        Edit Fields
-      </a>
     </div>
     <app-tags [entity]="entity"></app-tags>
   </div>

--- a/src/app/components/entity/entity.component.ts
+++ b/src/app/components/entity/entity.component.ts
@@ -51,6 +51,13 @@ export class EntityComponent implements OnInit {
           } as Field
         }))
         this.entityWithFields!.fields = _.orderBy(fieldsWithValues, "displayOrder")
+
+        // Assign a display field to be diplasyed as the entity's name
+        const { data: displayFieldTypeData } = await this.entityService.getDisplayFieldTypeId(this.entity!.entity_type_id!)
+        const displayFieldTypeId = displayFieldTypeData?.display_field_type_id
+        this.entityWithFields!.displayField = displayFieldTypeId
+          ? this.entityWithFields?.fields.find((field) => field.id === displayFieldTypeId)
+          : this.entityWithFields?.fields[0]
       }
     } catch (error) {
       if (error instanceof Error) {

--- a/src/app/core/services/entity/entity.service.ts
+++ b/src/app/core/services/entity/entity.service.ts
@@ -30,6 +30,10 @@ export class EntityService {
     return await this.supabase.from("entity").select("*").eq("id", entityId).limit(1).single()
   }
 
+  async getDisplayFieldTypeId(entityTypeId: number) {
+    return await this.supabase.from("entity_type").select("display_field_type_id").eq("id", entityTypeId).limit(1).single()
+  }
+
   async getFieldsForEntity(entityId: number) {
     return await this.supabase
       .from("entity_field_value")
@@ -104,5 +108,9 @@ export class EntityService {
         entity_type_id: entityTypeId
       })
       .select()
+  }
+
+  async deleteEntity(entityId: number) {
+    return await this.supabase.from("entity").delete().eq("id", entityId)
   }
 }

--- a/src/app/shared/models/database.types.ts
+++ b/src/app/shared/models/database.types.ts
@@ -12,32 +12,23 @@ export interface Database {
       entity: {
         Row: {
           created_at: string | null
-          display_field_type_id: number | null
           entity_type_id: number | null
           id: number
           name: string | null
         }
         Insert: {
           created_at?: string | null
-          display_field_type_id?: number | null
           entity_type_id?: number | null
           id?: number
           name?: string | null
         }
         Update: {
           created_at?: string | null
-          display_field_type_id?: number | null
           entity_type_id?: number | null
           id?: number
           name?: string | null
         }
         Relationships: [
-          {
-            foreignKeyName: "entity_display_field_type_id_fkey"
-            columns: ["display_field_type_id"]
-            referencedRelation: "entity_field_type"
-            referencedColumns: ["id"]
-          },
           {
             foreignKeyName: "entity_entity_type_id_fkey"
             columns: ["entity_type_id"]
@@ -205,6 +196,7 @@ export interface Database {
           collection_name: string | null
           created_at: string | null
           description: string | null
+          display_field_type_id: number | null
           display_order: number | null
           id: number
           name: string
@@ -213,6 +205,7 @@ export interface Database {
           collection_name?: string | null
           created_at?: string | null
           description?: string | null
+          display_field_type_id?: number | null
           display_order?: number | null
           id?: number
           name: string
@@ -221,11 +214,19 @@ export interface Database {
           collection_name?: string | null
           created_at?: string | null
           description?: string | null
+          display_field_type_id?: number | null
           display_order?: number | null
           id?: number
           name?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "entity_type_display_field_type_id_fkey"
+            columns: ["display_field_type_id"]
+            referencedRelation: "entity_field_type"
+            referencedColumns: ["id"]
+          }
+        ]
       }
     }
     Views: {

--- a/src/app/shared/models/entity.types.ts
+++ b/src/app/shared/models/entity.types.ts
@@ -12,6 +12,7 @@ export interface Field {
 }
 export interface EntityWithFields extends Entity {
   fields?: Field[]
+  displayField?: Field
 }
 export interface EntityWithFieldsAndTags extends EntityWithFields {
   tags?: Field[]

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -16,3 +16,8 @@ body {
 #page-content {
   margin: 32px;
 }
+
+.btn-danger {
+  background-color: red;
+  color: white;
+}


### PR DESCRIPTION
## Display field

The display name for an entity is no longer the `name` from the `entity` table itself. 

Instead, an entity type can specify a `display_field_type_id`, corresponding to a display field type, the value of which will be used as the display name for all entities of that type.

If an entity type does not specify a `display_field_type_id`, then by default the first field type of that entity (ordered by `display_order` will be used. However, all entity types should specify a `display_field_type_id`.

Eventually, we should support display names being constructed from multiple field values, see #24. 

### Legacy entity names

Currently, when editing an entity's fields, the legacy entity `name` is displayed, so that it can be copied over to the relevant field (usually a field called "name"). See screenshot below:
<img width="600" alt="Screenshot 2023-09-01 at 11 54 58" src="https://github.com/jfmcquade/staff-database/assets/64838927/85737aa5-bf50-4ce1-bfea-2cdbb11b8f35">

I've already copied over all such names for the Initiatives, but the same should be done for other entity types. After this point, the `name` column of the `entity` table should be deleted, and this feature removed from the code.

## Delete entities

Adds ability to delete entities (red button at bottom of page):

<img width="600" alt="Screenshot 2023-09-01 at 12 38 27" src="https://github.com/jfmcquade/staff-database/assets/64838927/bc3d1925-f944-49e8-9439-5a58caa15b2d">

<img width="600" alt="Screenshot 2023-09-01 at 13 00 41" src="https://github.com/jfmcquade/staff-database/assets/64838927/78ce3cad-8c4b-4db4-a2e4-10adbdba442d">
